### PR TITLE
Generate new SECRET_KEY when using the repo as `startproject` template

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'i+acxn5(akgsn!sr4^qgf(^m&*@+g1@u^t@=8s@axc41ml*f=s'
+SECRET_KEY = {{ secret_key }}
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Minor security nitpick. People using the repo as template for `django-admin.py startproject ...` might forget altering the `SECRET_KEY` on their directory when deploying to Heroku. This is handled by using template tag `{{ secret_key }}`.