### PR TITLE
Update readme to call migrate instead of syncdb

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ You can replace ``helloworld`` with your desired project name.
     $ heroku create
     $ git push heroku master
 
-    $ heroku run python manage.py syncdb
+    $ heroku run python manage.py migrate
 
 ## Further Reading
 


### PR DESCRIPTION
`syncdb` is deprecated as of Django 1.7