### PR TITLE
added missing quote marks around secret_key, fix problems from PR#10

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -19,7 +19,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 # See https://docs.djangoproject.com/en/1.7/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = {{ secret_key }}
+SECRET_KEY = "{{ secret_key }}"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
Sorry, I forgot to add surrounding quote marks to `{{ secret_key }}` from the last PR. Creating a project from the template should work properly now.