### PR TITLE
Fix BASE_DIR

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -13,7 +13,7 @@ import os
 import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
 # Quick-start development settings - unsuitable for production


### PR DESCRIPTION
My web app would send status 500 until I made this change to the BASE_DIR.

Fix works for my web app:
https://recipeminder.herokuapp.com/recipes/
https://github.com/edsfocci/recipeminder-ed/commit/ac5385569c22e1e337dc62ec08e364dde586889c

Hopefully this fix helps others as well. Using Django 1.8.2

Also, this fix may be related to this issue:
https://github.com/heroku/heroku-django-template/issues/9