### PR TITLE
Remove BASE_DIR and DATABASE complexity

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -13,8 +13,7 @@ import os
 import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
-BASE_DIR = os.path.dirname(os.path.dirname(__file__))
-
+BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/1.8/howto/deployment/checklist/
@@ -74,12 +73,11 @@ WSGI_APPLICATION = '{{ project_name}}.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
-    }
-}
+# Parse database configuration from $DATABASE_URL
+DATABASES = {'default': dj_database_url.config()}
+
+# Enable Connection Pooling (if desired)
+DATABASES['default']['ENGINE'] = 'django_postgrespool'
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
@@ -90,13 +88,6 @@ USE_I18N = True
 USE_L10N = True
 USE_TZ = True
 
-
-# Parse database configuration from $DATABASE_URL
-DATABASES['default'] = dj_database_url.config()
-
-# Enable Connection Pooling (if desired)
-DATABASES['default']['ENGINE'] = 'django_postgrespool'
-
 # Honor the 'X-Forwarded-Proto' header for request.is_secure()
 SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
 
@@ -106,7 +97,6 @@ ALLOWED_HOSTS = ['*']
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.7/howto/static-files/
 
-BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 STATIC_ROOT = 'staticfiles'
 STATIC_URL = '/static/'
 


### PR DESCRIPTION
`BASE_DIR` is being set two times to two different locations. This is confusing. 

The first `BASE_DIR` setting is used for the initial `DATABASES` setting that is never used and immediately overridden by `dj_database_url`. I removed this `DATABASES` setting.

The second `BASE_DIR` is used for `STATICFILES_DIRS`. I replaced the first `BASE_DIR` with this one.
