### PR TITLE
Removed deprecated TEMPLATE_DEBUG setting from settings.py

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -61,7 +61,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
-            'debug': True,
+            'debug': DEBUG,
         },
     },
 ]

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -25,9 +25,6 @@ SECRET_KEY = "{{ secret_key }}"
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-TEMPLATE_DEBUG = True
-
-
 # Application definition
 
 INSTALLED_APPS = (
@@ -64,6 +61,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
             ],
+            'debug': True,
         },
     },
 ]


### PR DESCRIPTION
Added debug option in OPTIONS of TEMPLATES instead
[Reference](https://docs.djangoproject.com/en/1.8/ref/settings/#template-debug)