### PR TITLE
Remove redundant gunicorn option `--log-file -`

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn {{ project_name }}.wsgi --log-file -
+web: gunicorn {{ project_name }}.wsgi


### PR DESCRIPTION
The `--log-file` option was renamed to `--error-logfile` in gunicorn v0.13.0. However since gunicorn v19.2 it now defaults to `-` (stderr), so can be omitted entirely:
http://docs.gunicorn.org/en/latest/settings.html#errorlog