### PR TITLE
Update to WhiteNoise 3.2

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -34,6 +34,10 @@ INSTALLED_APPS = [
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
+    # Disable Django's own staticfiles handling in favour of WhiteNoise, for
+    # greater consistency between gunicorn and `./manage.py runserver`. See:
+    # http://whitenoise.evans.io/en/stable/django.html#using-whitenoise-in-development
+    'whitenoise.runserver_nostatic',
     'django.contrib.staticfiles',
 ]
 

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -28,16 +28,17 @@ DEBUG = True
 
 # Application definition
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-)
+]
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE_CLASSES = [
+    'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -45,12 +46,11 @@ MIDDLEWARE_CLASSES = (
     'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-    'django.middleware.security.SecurityMiddleware',
-)
+]
 
 ROOT_URLCONF = '{{ project_name }}.urls'
 
-TEMPLATES = (
+TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',
         'DIRS': [],
@@ -65,7 +65,7 @@ TEMPLATES = (
             'debug': DEBUG,
         },
     },
-)
+]
 
 WSGI_APPLICATION = '{{ project_name}}.wsgi.application'
 
@@ -80,7 +80,7 @@ DATABASES = {
     }
 }
 
-AUTH_PASSWORD_VALIDATORS = (
+AUTH_PASSWORD_VALIDATORS = [
     {
         'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
     },
@@ -93,7 +93,7 @@ AUTH_PASSWORD_VALIDATORS = (
     {
         'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
     },
-)
+]
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.9/topics/i18n/

--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
 
 MIDDLEWARE_CLASSES = [
     'django.middleware.security.SecurityMiddleware',
+    'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -127,4 +128,4 @@ STATICFILES_DIRS = [
 
 # Simplified static file serving.
 # https://warehouse.python.org/project/whitenoise/
-STATICFILES_STORAGE = 'whitenoise.django.GzipManifestStaticFilesStorage'
+STATICFILES_STORAGE = 'whitenoise.storage.CompressedManifestStaticFilesStorage'

--- a/project_name/urls.py
+++ b/project_name/urls.py
@@ -1,10 +1,21 @@
-from django.conf.urls import include, url
+"""{{ project_name }} URL Configuration
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/{{ docs_version }}/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  url(r'^$', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  url(r'^$', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.conf.urls import url, include
+    2. Add a URL to urlpatterns:  url(r'^blog/', include('blog.urls'))
+"""
+from django.conf.urls import url
 from django.contrib import admin
 
 urlpatterns = [
-    # Examples:
-    # url(r'^$', '{{ project_name }}.views.home', name='home'),
-    # url(r'^blog/', include('blog.urls')),
-
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 ]

--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -4,11 +4,12 @@ WSGI config for {{ project_name }} project.
 It exposes the WSGI callable as a module-level variable named ``application``.
 
 For more information on this file, see
-https://docs.djangoproject.com/en/1.7/howto/deployment/wsgi/
+https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 """
 
-
 import os
+
+# Must be defined prior to importing `whitenoise.django`.
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 
 from django.core.wsgi import get_wsgi_application

--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -9,11 +9,8 @@ https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 
 import os
 
-# Must be defined prior to importing `whitenoise.django`.
+from django.core.wsgi import get_wsgi_application
+
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 
-from django.core.wsgi import get_wsgi_application
-from whitenoise.django import DjangoWhiteNoise
-
 application = get_wsgi_application()
-application = DjangoWhiteNoise(application)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ dj-database-url==0.4.0
 Django==1.9.2
 gunicorn==19.4.5
 psycopg2==2.6.1
-whitenoise==2.0.6
+whitenoise==3.2


### PR DESCRIPTION
* Sync templates with changes made to the default Django 1.9 project templates (mainly since `SecurityMiddleware` should go before the new `WhiteNoiseMiddleware`)
* Update WhiteNoise from v2.0.6 to v3.2.
* Use WhiteNoise 3.0's new runserver_nostatic feature.

See individual commit messages for more details :-)