### PR TITLE
Add DjangoWhiteNoise in wsgi.py

### DIFF
--- a/project_name/wsgi.py
+++ b/project_name/wsgi.py
@@ -10,7 +10,9 @@ https://docs.djangoproject.com/en/1.9/howto/deployment/wsgi/
 import os
 
 from django.core.wsgi import get_wsgi_application
+from whitenoise.django import DjangoWhiteNoise
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "{{ project_name }}.settings")
 
 application = get_wsgi_application()
+application = DjangoWhiteNoise(application)


### PR DESCRIPTION
According to Heroku's documentation whitenoise call should be added on wsgi: https://devcenter.heroku.com/articles/django-app-configuration#whitenoise