### PR TITLE
update middleware setting

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -41,7 +41,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
 ]
 
-MIDDLEWARE_CLASSES = [
+MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',


### PR DESCRIPTION
Hi, just saw the MIDDLEWARE_CLASSES setting in settings.py file (deprecated in 1.10). This is  updated in favour of MIDDLEWARE.  Should address https://github.com/heroku/heroku-django-template/issues/55.