### PR TITLE
settings: remove SessionAuthenticationMiddleware

### DIFF
--- a/project_name/settings.py
+++ b/project_name/settings.py
@@ -48,7 +48,6 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.auth.middleware.SessionAuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
 ]


### PR DESCRIPTION
According to the 1.10 release notes [1] it has no purpose and can be removed.

[1] https://docs.djangoproject.com/en/1.10/releases/1.10/#features-removed-in-1-10