### PR TITLE
Update psycopg2 to work with PostgreSQL 10

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.4.1
 Django==1.11.1
 gunicorn==19.6.0
-psycopg2==2.6.2
+psycopg2==2.7.3.1
 whitenoise==3.2


### PR DESCRIPTION
Collecting psycopg2==2.6.2 (from -r requirements.txt (line 4))
  Using cached psycopg2-2.6.2.tar.gz
    Complete output from command python setup.py egg_info:
    running egg_info
    creating pip-egg-info/psycopg2.egg-info
    writing pip-egg-info/psycopg2.egg-info/PKG-INFO
    writing top-level names to pip-egg-info/psycopg2.egg-info/top_level.txt
    writing dependency_links to pip-egg-info/psycopg2.egg-info/dependency_links.txt
    writing manifest file 'pip-egg-info/psycopg2.egg-info/SOURCES.txt'
    Error: could not determine PostgreSQL version from '10.0'
    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-xwnjc34q/psycopg2/