### PR TITLE
updates psycopg2 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 dj-database-url==0.4.1
 Django==1.11.1
 gunicorn==19.6.0
-psycopg2==2.6.2
+psycopg2==2.7.3.1
 whitenoise==3.2


### PR DESCRIPTION
I could easily be making a mistake elsewhere, but I got this fix from following https://github.com/openshift/django-ex/issues/103 to https://github.com/openshift/django-ex/pull/104/files after getting the error `Error: could not determine PostgreSQL version from '10.1'` trying to run `pip install -r requirements` with the template