### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ venv
 staticfiles
 .env
 *.sqlite3
+.venv/


### PR DESCRIPTION
As pipenv uses `.venv` directory if `PIPENV_VENV_IN_PROJECT` is set to 1,
It would be better if default `.gitignore` ignores `.venv` folder.