### PR TITLE
Remove python_version from Pipfile

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,11 +5,6 @@ verify_ssl = true
 name = "pypi"
 
 
-[requires]
-
-python_version = "3.6"
-
-
 [packages]
 
 "psycopg2-binary" = "*"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ An utterly fantastic project starter template for Django 2.0.
 
 - Production-ready configuration for Static Files, Database Settings, Gunicorn, etc.
 - Enhancements to Django's static file serving functionality via WhiteNoise.
-- Latest Python 3.6 runtime environment.
 
 ## How to Use
 


### PR DESCRIPTION
I think there's no need to specify `python_version` in `Pipfile`. The template works for newer Python versions as well. We can't specify multiple Python versions in `Pipfile`, but we can remove it.